### PR TITLE
feat: add turborepo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,4 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Test
-        run: yarn test --ci --coverage --maxWorkers=2
+        run: yarn test:ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ cd react-toolkit
 In one terminal, run tsdx watch in parallel:
 
 ```sh
-yarn start
+yarn dev
 ```
 
 This builds each package to `<packages>/<package>/dist` and runs the project in

--- a/docs/configs/search-meta.json
+++ b/docs/configs/search-meta.json
@@ -1,14 +1,14 @@
 [
   {
     "content": "Getting Started",
-    "id": "17ed68fb-617e-4606-8843-1fe2623e9d03",
+    "id": "add9056f-a353-4ec5-bf15-75dfb121981f",
     "type": "lvl1",
     "url": "/getting-started",
     "hierarchy": { "lvl1": "Getting Started" }
   },
   {
     "content": "Installation",
-    "id": "396299f0-f079-4826-b2e6-e637e9216fb9",
+    "id": "aa37a35e-121d-4b5a-bdd5-7231c8436bf2",
     "type": "lvl2",
     "url": "/getting-started#installation",
     "hierarchy": {
@@ -19,7 +19,7 @@
   },
   {
     "content": "React Hooks",
-    "id": "a0706657-7d39-48e6-b7ae-38c000e888db",
+    "id": "470d6ddc-64f5-407a-9ce3-ded680286518",
     "type": "lvl3",
     "url": "/getting-started#react-hooks",
     "hierarchy": {
@@ -30,7 +30,7 @@
   },
   {
     "content": "React Utilities",
-    "id": "2c1b8c48-f048-42cd-857d-1c3809a44f41",
+    "id": "499afea7-1f19-4985-a91d-74d7ee288102",
     "type": "lvl3",
     "url": "/getting-started#react-utilities",
     "hierarchy": {
@@ -41,42 +41,74 @@
   },
   {
     "content": "React Hooks",
-    "id": "4a893a59-a6a0-46e5-be74-c60de897cf96",
+    "id": "13f18434-a45f-4c6c-88a9-0fa4b516d3bd",
     "type": "lvl1",
     "url": "/hooks/",
     "hierarchy": { "lvl1": "React Hooks" }
   },
   {
     "content": "Installation",
-    "id": "d334a0ae-116d-4eb5-9894-51ad1c2ef558",
+    "id": "5669a3ce-69cd-4977-895f-8d328f795fdf",
     "type": "lvl2",
     "url": "/hooks/#installation",
     "hierarchy": { "lvl1": "React Hooks", "lvl2": "Installation", "lvl3": null }
   },
   {
     "content": "Import",
-    "id": "60c6a045-846b-416a-8fb3-87331c8243be",
+    "id": "28d19c97-85c3-4146-b565-97f4966114ea",
     "type": "lvl2",
     "url": "/hooks/#import",
     "hierarchy": { "lvl1": "React Hooks", "lvl2": "Import", "lvl3": null }
   },
   {
+    "content": "useAsyncEffect",
+    "id": "ac83041e-fca7-4545-96ac-d494a5e6208e",
+    "type": "lvl1",
+    "url": "/hooks/use-async-effect",
+    "hierarchy": { "lvl1": "useAsyncEffect" }
+  },
+  {
+    "content": "Import",
+    "id": "758005d6-a82e-4a65-863a-abd2becb1240",
+    "type": "lvl2",
+    "url": "/hooks/use-async-effect#import",
+    "hierarchy": { "lvl1": "useAsyncEffect", "lvl2": "Import", "lvl3": null }
+  },
+  {
+    "content": "Usage",
+    "id": "d345b468-df3e-4c42-aeaa-6de85b0480cd",
+    "type": "lvl2",
+    "url": "/hooks/use-async-effect#usage",
+    "hierarchy": { "lvl1": "useAsyncEffect", "lvl2": "Usage", "lvl3": null }
+  },
+  {
+    "content": "Parameters",
+    "id": "30bcbb8e-17c1-42f0-9930-89197daf0ffe",
+    "type": "lvl2",
+    "url": "/hooks/use-async-effect#parameters",
+    "hierarchy": {
+      "lvl1": "useAsyncEffect",
+      "lvl2": "Parameters",
+      "lvl3": null
+    }
+  },
+  {
     "content": "useClipboard",
-    "id": "5cfb5f7d-a093-432f-9fb8-664e24740427",
+    "id": "b963abad-1a13-4425-be7b-a642c8f5b56a",
     "type": "lvl1",
     "url": "/hooks/use-clipboard",
     "hierarchy": { "lvl1": "useClipboard" }
   },
   {
     "content": "Import",
-    "id": "09d441bc-67ed-4359-83bc-ba478eac09ca",
+    "id": "d8a2edee-d1f4-44c9-ad38-2636ed8cef18",
     "type": "lvl2",
     "url": "/hooks/use-clipboard#import",
     "hierarchy": { "lvl1": "useClipboard", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "6017dae8-81c3-439c-8024-a53a3695639c",
+    "id": "806122a4-4a7d-4b9e-bb44-a57ae5b94072",
     "type": "lvl2",
     "url": "/hooks/use-clipboard#return-value",
     "hierarchy": {
@@ -87,105 +119,105 @@
   },
   {
     "content": "Usage",
-    "id": "884711a9-e704-4ed7-a401-d7143c5cd994",
+    "id": "0603f700-a0b2-48df-b3fd-cb73436dba71",
     "type": "lvl2",
     "url": "/hooks/use-clipboard#usage",
     "hierarchy": { "lvl1": "useClipboard", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "0b27cce3-5170-478b-919e-4d0ea0a26ba8",
+    "id": "129ef76d-a834-47c9-abee-06f00930ba8f",
     "type": "lvl2",
     "url": "/hooks/use-clipboard#parameters",
     "hierarchy": { "lvl1": "useClipboard", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "useConstant",
-    "id": "775eb9fd-1db2-4e66-8acb-955056848333",
+    "id": "f89b1c49-f4f5-4aed-852c-a6bcd2eb09b7",
     "type": "lvl1",
     "url": "/hooks/use-constant",
     "hierarchy": { "lvl1": "useConstant" }
   },
   {
     "content": "Import",
-    "id": "336c0035-5e31-4c95-9f89-16182afe903e",
+    "id": "ee5a670e-c002-431e-87aa-c770e64ec8f4",
     "type": "lvl2",
     "url": "/hooks/use-constant#import",
     "hierarchy": { "lvl1": "useConstant", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "428b56bd-6e36-4295-9f9a-26a5f093e9fe",
+    "id": "9b4f2c92-a380-4a41-940a-d6a48ecf6f47",
     "type": "lvl2",
     "url": "/hooks/use-constant#return-value",
     "hierarchy": { "lvl1": "useConstant", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "acd16ee0-1f85-41fc-9753-d8ddded3b68d",
+    "id": "a5ce105d-02e9-4939-91d9-9d2bc7663b71",
     "type": "lvl2",
     "url": "/hooks/use-constant#usage",
     "hierarchy": { "lvl1": "useConstant", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "f8c1cf3c-dec7-415a-8f54-1201bfef1c0e",
+    "id": "ca652dea-373f-43ad-ae30-a1e89817819e",
     "type": "lvl2",
     "url": "/hooks/use-constant#parameters",
     "hierarchy": { "lvl1": "useConstant", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "useDebounce",
-    "id": "2bb5897a-cba1-48dc-abd3-3e10cf70f9f8",
+    "id": "0d1d0332-183c-485a-8f86-8e6938731c90",
     "type": "lvl1",
     "url": "/hooks/use-debounce",
     "hierarchy": { "lvl1": "useDebounce" }
   },
   {
     "content": "Import",
-    "id": "27f3dfe7-40f6-4d26-bf00-ecc5da9b0fcf",
+    "id": "95fbe527-c85b-42d3-b764-d5f292037526",
     "type": "lvl2",
     "url": "/hooks/use-debounce#import",
     "hierarchy": { "lvl1": "useDebounce", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "e0ecaacf-cba0-4b21-915c-56b6d5eea017",
+    "id": "4b1c3c32-191a-4d3d-ab21-99fb62c63221",
     "type": "lvl2",
     "url": "/hooks/use-debounce#return-value",
     "hierarchy": { "lvl1": "useDebounce", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "7c445040-eafd-4d9f-bcea-d07e31a5c3be",
+    "id": "1594c07d-7a2c-4a32-9c9d-e258f1b5a927",
     "type": "lvl2",
     "url": "/hooks/use-debounce#usage",
     "hierarchy": { "lvl1": "useDebounce", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "bbd9cf8e-e001-40e9-b5fb-ea5b44f9c09d",
+    "id": "625135ef-537f-401d-ad67-e8ca9bccf3aa",
     "type": "lvl2",
     "url": "/hooks/use-debounce#parameters",
     "hierarchy": { "lvl1": "useDebounce", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "useDisclosure",
-    "id": "dfb36bd1-e2c0-467e-b5f3-059cf61b2372",
+    "id": "7d054bc1-74cf-47d5-a96b-dac61086faeb",
     "type": "lvl1",
     "url": "/hooks/use-disclosure",
     "hierarchy": { "lvl1": "useDisclosure" }
   },
   {
     "content": "Import",
-    "id": "2979b9d3-cf47-4278-8a0a-81083090f670",
+    "id": "fee46200-c7de-4e87-81b9-3300578b32bc",
     "type": "lvl2",
     "url": "/hooks/use-disclosure#import",
     "hierarchy": { "lvl1": "useDisclosure", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "603cfaa0-2a8f-4c3c-9fe1-f9fc28cc78ec",
+    "id": "bca916a8-2c8a-4a95-a1b4-c0fe6cc9cb28",
     "type": "lvl2",
     "url": "/hooks/use-disclosure#return-value",
     "hierarchy": {
@@ -196,56 +228,116 @@
   },
   {
     "content": "Usage",
-    "id": "8e8a4cfb-3101-4ab4-9571-14dedbfab8fe",
+    "id": "c07f4108-5085-472c-8b76-fdf3a6de2f34",
     "type": "lvl2",
     "url": "/hooks/use-disclosure#usage",
     "hierarchy": { "lvl1": "useDisclosure", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "704a446b-36b3-41f9-9ba5-9ccf897dbf74",
+    "id": "66396f91-bc83-48de-8bfa-cf5fc69a4327",
     "type": "lvl2",
     "url": "/hooks/use-disclosure#parameters",
     "hierarchy": { "lvl1": "useDisclosure", "lvl2": "Parameters", "lvl3": null }
   },
   {
+    "content": "useHasMounted",
+    "id": "69179476-9332-48a2-93c0-66b1cdc169fa",
+    "type": "lvl1",
+    "url": "/hooks/use-has-mounted",
+    "hierarchy": { "lvl1": "useHasMounted" }
+  },
+  {
+    "content": "Import",
+    "id": "0b0a4ad3-db7c-4e09-9b2c-0b0635905248",
+    "type": "lvl2",
+    "url": "/hooks/use-has-mounted#import",
+    "hierarchy": { "lvl1": "useHasMounted", "lvl2": "Import", "lvl3": null }
+  },
+  {
+    "content": "Return value",
+    "id": "e327e294-c382-4c13-9dfd-c38cff98fb2f",
+    "type": "lvl2",
+    "url": "/hooks/use-has-mounted#return-value",
+    "hierarchy": {
+      "lvl1": "useHasMounted",
+      "lvl2": "Return value",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Usage",
+    "id": "ba9c16f8-f510-40b5-b0e3-6e40559ab566",
+    "type": "lvl2",
+    "url": "/hooks/use-has-mounted#usage",
+    "hierarchy": { "lvl1": "useHasMounted", "lvl2": "Usage", "lvl3": null }
+  },
+  {
     "content": "useLockBodyScroll",
-    "id": "874900ac-b687-4ebf-8690-ecd9116e82a1",
+    "id": "fa397cc1-e9fd-4749-ae65-d7b9bb0f798b",
     "type": "lvl1",
     "url": "/hooks/use-lock-body-scroll",
     "hierarchy": { "lvl1": "useLockBodyScroll" }
   },
   {
     "content": "Import",
-    "id": "2655d815-545a-4e80-991e-1f424f7565b8",
+    "id": "1f2e87c0-f64a-4a77-a541-bff2010f62ca",
     "type": "lvl2",
     "url": "/hooks/use-lock-body-scroll#import",
     "hierarchy": { "lvl1": "useLockBodyScroll", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "8181bf5d-795d-4b1b-9c26-d70a63be749f",
+    "id": "e316c7e2-a640-4690-9093-809380ce1178",
     "type": "lvl2",
     "url": "/hooks/use-lock-body-scroll#usage",
     "hierarchy": { "lvl1": "useLockBodyScroll", "lvl2": "Usage", "lvl3": null }
   },
   {
+    "content": "useMedia",
+    "id": "1df78563-34b1-459e-9a28-51c4d8fc5c72",
+    "type": "lvl1",
+    "url": "/hooks/use-media",
+    "hierarchy": { "lvl1": "useMedia" }
+  },
+  {
+    "content": "Import",
+    "id": "d8444553-559e-4fb7-9e28-ed112bdc1fd2",
+    "type": "lvl2",
+    "url": "/hooks/use-media#import",
+    "hierarchy": { "lvl1": "useMedia", "lvl2": "Import", "lvl3": null }
+  },
+  {
+    "content": "Usage",
+    "id": "5766a586-73db-4a2f-a87d-2928f33ff6c4",
+    "type": "lvl2",
+    "url": "/hooks/use-media#usage",
+    "hierarchy": { "lvl1": "useMedia", "lvl2": "Usage", "lvl3": null }
+  },
+  {
+    "content": "Parameters",
+    "id": "43d536d5-97de-426a-9a2c-c77e35f3968a",
+    "type": "lvl2",
+    "url": "/hooks/use-media#parameters",
+    "hierarchy": { "lvl1": "useMedia", "lvl2": "Parameters", "lvl3": null }
+  },
+  {
     "content": "useMergeRefs",
-    "id": "fcfa8ea1-40fb-4357-9d06-791bbb455b33",
+    "id": "6abd602c-6fd1-43c8-b1dc-3bde096e195b",
     "type": "lvl1",
     "url": "/hooks/use-merge-refs",
     "hierarchy": { "lvl1": "useMergeRefs" }
   },
   {
     "content": "Import",
-    "id": "01e94282-f36b-4b1e-a79b-9e0c89eaf0ea",
+    "id": "ad487b18-f8c1-49a8-8b52-d2cbc2ca3e36",
     "type": "lvl2",
     "url": "/hooks/use-merge-refs#import",
     "hierarchy": { "lvl1": "useMergeRefs", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "b22e19e1-d486-4668-854f-a7402dab7c96",
+    "id": "f6b3fc40-6a03-4955-b08e-688a2cdbef32",
     "type": "lvl2",
     "url": "/hooks/use-merge-refs#return-value",
     "hierarchy": {
@@ -256,56 +348,88 @@
   },
   {
     "content": "Usage",
-    "id": "41edad9f-0b96-494a-889f-74b2a41060c6",
+    "id": "df74e6c4-f075-4fe1-966a-17bd55722f42",
     "type": "lvl2",
     "url": "/hooks/use-merge-refs#usage",
     "hierarchy": { "lvl1": "useMergeRefs", "lvl2": "Usage", "lvl3": null }
   },
   {
+    "content": "useOnClickOutside",
+    "id": "4f0bbfe7-2a68-4d1f-95c3-2d555a57d994",
+    "type": "lvl1",
+    "url": "/hooks/use-onclick-outside",
+    "hierarchy": { "lvl1": "useOnClickOutside" }
+  },
+  {
+    "content": "Import",
+    "id": "183162bb-5975-4067-bd24-524c5a6f288f",
+    "type": "lvl2",
+    "url": "/hooks/use-onclick-outside#import",
+    "hierarchy": { "lvl1": "useOnClickOutside", "lvl2": "Import", "lvl3": null }
+  },
+  {
+    "content": "Usage",
+    "id": "9d878d2c-65f1-4c2d-bd1e-364910e34796",
+    "type": "lvl2",
+    "url": "/hooks/use-onclick-outside#usage",
+    "hierarchy": { "lvl1": "useOnClickOutside", "lvl2": "Usage", "lvl3": null }
+  },
+  {
+    "content": "Parameters",
+    "id": "e7aaf2d7-89ce-4728-ab59-97e0f1feca67",
+    "type": "lvl2",
+    "url": "/hooks/use-onclick-outside#parameters",
+    "hierarchy": {
+      "lvl1": "useOnClickOutside",
+      "lvl2": "Parameters",
+      "lvl3": null
+    }
+  },
+  {
     "content": "usePrevious",
-    "id": "e58f89e7-b280-400f-9a81-b402ba1c39fb",
+    "id": "1f570a11-e956-4152-bf0f-91fc94b9b2b8",
     "type": "lvl1",
     "url": "/hooks/use-previous",
     "hierarchy": { "lvl1": "usePrevious" }
   },
   {
     "content": "Import",
-    "id": "765e9666-a72c-4fa2-91c0-c6437a89774d",
+    "id": "053b1dd2-01b0-465e-8cfe-336c99ec5303",
     "type": "lvl2",
     "url": "/hooks/use-previous#import",
     "hierarchy": { "lvl1": "usePrevious", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "07097b79-4d6a-4d75-ae19-aa84b814890c",
+    "id": "d26dd7d1-2683-469b-ad94-84dc6cf87140",
     "type": "lvl2",
     "url": "/hooks/use-previous#return-value",
     "hierarchy": { "lvl1": "usePrevious", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "ea5a78ec-d49a-484f-bbda-dbd38472e166",
+    "id": "c353d7e0-889f-49e0-ae1d-7e8f190fa2ff",
     "type": "lvl2",
     "url": "/hooks/use-previous#usage",
     "hierarchy": { "lvl1": "usePrevious", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "47c2edfb-e00e-4021-9d55-be31bfd80afe",
+    "id": "054737d4-dc38-416d-b4ee-c7cc0f482449",
     "type": "lvl2",
     "url": "/hooks/use-previous#parameters",
     "hierarchy": { "lvl1": "usePrevious", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "useWhyDidYouUpdate",
-    "id": "988d603d-e8d1-484c-bc92-897265d7e2f1",
+    "id": "8485baf6-2fc3-455a-a534-25479a6a1db4",
     "type": "lvl1",
     "url": "/hooks/use-why-did-you-update",
     "hierarchy": { "lvl1": "useWhyDidYouUpdate" }
   },
   {
     "content": "Import",
-    "id": "7ebcc215-b444-4759-b544-23604e4bc401",
+    "id": "f34b5932-54ea-4bd7-8e91-295a18751c3f",
     "type": "lvl2",
     "url": "/hooks/use-why-did-you-update#import",
     "hierarchy": {
@@ -316,7 +440,7 @@
   },
   {
     "content": "Return value",
-    "id": "82152a6b-d8c9-42a5-92e2-96ad7c8ea377",
+    "id": "3cd47496-abb7-46d1-bd26-fc734af2a7f7",
     "type": "lvl2",
     "url": "/hooks/use-why-did-you-update#return-value",
     "hierarchy": {
@@ -327,14 +451,14 @@
   },
   {
     "content": "Usage",
-    "id": "284b01e5-f455-4b92-8d9b-ef4e27532bc5",
+    "id": "6a55ad6c-bfb8-4446-b9b0-e46c6d4c7c41",
     "type": "lvl2",
     "url": "/hooks/use-why-did-you-update#usage",
     "hierarchy": { "lvl1": "useWhyDidYouUpdate", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "6d88a8e8-d0e7-4ac5-83e1-53f574111fec",
+    "id": "63c19ade-222b-473c-9130-c69d458e0301",
     "type": "lvl2",
     "url": "/hooks/use-why-did-you-update#parameters",
     "hierarchy": {
@@ -345,28 +469,28 @@
   },
   {
     "content": "React Toolkit",
-    "id": "cd1e754c-68af-4bfa-a046-f37cd99f36de",
+    "id": "61cf27a4-7e89-4c54-898b-1b2cf2497f19",
     "type": "lvl1",
     "url": "/",
     "hierarchy": { "lvl1": "React Toolkit" }
   },
   {
     "content": "callAllHandlers",
-    "id": "d15e02fc-ba5b-4f0b-9821-6f9693770f9b",
+    "id": "17772926-3b26-4fb7-8ee7-68c6a23fc809",
     "type": "lvl1",
     "url": "/utils/call-all-handlers",
     "hierarchy": { "lvl1": "callAllHandlers" }
   },
   {
     "content": "Import",
-    "id": "03d2436b-8165-482b-83aa-d5169baa2bec",
+    "id": "7141feb1-74f5-4f48-b066-3e6f82585db7",
     "type": "lvl2",
     "url": "/utils/call-all-handlers#import",
     "hierarchy": { "lvl1": "callAllHandlers", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "4c79477c-901a-4186-acaa-3480e02daa9c",
+    "id": "af7c7be3-553c-4943-81e6-46c88d3255c1",
     "type": "lvl2",
     "url": "/utils/call-all-handlers#return-value",
     "hierarchy": {
@@ -377,28 +501,28 @@
   },
   {
     "content": "Usage",
-    "id": "931e8079-ead8-47ed-b531-0d0fd40316d5",
+    "id": "cf9ee969-eef2-4cf9-b4f8-bb18cff634db",
     "type": "lvl2",
     "url": "/utils/call-all-handlers#usage",
     "hierarchy": { "lvl1": "callAllHandlers", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "cleanChildren",
-    "id": "45b8d204-ca35-46ed-8ee0-6347a4b3891b",
+    "id": "94e8a58a-1b8e-46c1-a22a-649a1d7d187a",
     "type": "lvl1",
     "url": "/utils/clean-children",
     "hierarchy": { "lvl1": "cleanChildren" }
   },
   {
     "content": "Import",
-    "id": "af2c922c-b413-4025-bcd3-d6af47ad3023",
+    "id": "a98c2198-e6b4-46e7-8227-8950f3ad99fd",
     "type": "lvl2",
     "url": "/utils/clean-children#import",
     "hierarchy": { "lvl1": "cleanChildren", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "eb8249c1-b7a5-4c31-b2e3-d3fed1ae12bb",
+    "id": "aa5c64fa-6f25-471c-b26d-ec21d4073674",
     "type": "lvl2",
     "url": "/utils/clean-children#return-value",
     "hierarchy": {
@@ -409,140 +533,151 @@
   },
   {
     "content": "Usage",
-    "id": "44a25694-47e2-405c-83e3-cc02f42ef8ff",
+    "id": "7c1f6fdd-ceba-49b0-a00c-78cf38c3575d",
     "type": "lvl2",
     "url": "/utils/clean-children#usage",
     "hierarchy": { "lvl1": "cleanChildren", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "createContext",
-    "id": "1a99756f-d568-46ca-98db-fd002bdd8081",
+    "id": "668d23a9-a44d-4b0b-b7dd-f4124b86b1b3",
     "type": "lvl1",
     "url": "/utils/create-context",
     "hierarchy": { "lvl1": "createContext" }
   },
   {
     "content": "Import",
-    "id": "c6e8dea2-e7e2-4a6f-b22b-b1ea64164617",
+    "id": "43742fb9-5132-46d9-a2cc-4ec0b4a6bf64",
     "type": "lvl2",
     "url": "/utils/create-context#import",
     "hierarchy": { "lvl1": "createContext", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "99c0f7b2-6341-406b-a890-bc946630466e",
+    "id": "2e7ef0e0-3db6-4e1d-ad02-47c3a1ec5b86",
     "type": "lvl2",
     "url": "/utils/create-context#usage",
     "hierarchy": { "lvl1": "createContext", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "React Utils",
-    "id": "b763f8f8-d5e7-41d3-8427-7457fc3c0e38",
+    "id": "ad5a17c2-ce59-44a0-8d9b-999d15e9547a",
     "type": "lvl1",
     "url": "/utils/",
     "hierarchy": { "lvl1": "React Utils" }
   },
   {
     "content": "Installation",
-    "id": "d336b0aa-8e70-4083-81a3-bf33bd4a4bc0",
+    "id": "415188ff-0c5c-4f7c-8f3a-548bd3aefe85",
     "type": "lvl2",
     "url": "/utils/#installation",
     "hierarchy": { "lvl1": "React Utils", "lvl2": "Installation", "lvl3": null }
   },
   {
     "content": "Import",
-    "id": "b30da4b9-1356-4c42-85a0-d611c2f62ef5",
+    "id": "0044f242-ccff-483c-a18e-142d5688a74c",
     "type": "lvl2",
     "url": "/utils/#import",
     "hierarchy": { "lvl1": "React Utils", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "isSSR",
-    "id": "3010b452-c203-4e75-a44d-79bb55152a5e",
+    "id": "e5a5c12c-b401-4c9e-8c52-4f8b94a82cee",
     "type": "lvl1",
     "url": "/utils/is-ssr",
     "hierarchy": { "lvl1": "isSSR" }
   },
   {
     "content": "Import",
-    "id": "2746aa51-b77f-4aff-8595-9312587de89f",
+    "id": "5aced3aa-14cf-451a-b875-7c47b8b9d58f",
     "type": "lvl2",
     "url": "/utils/is-ssr#import",
     "hierarchy": { "lvl1": "isSSR", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "d25fbbd7-deaa-4814-bf5a-5335262fb1a2",
+    "id": "627bb3e3-3333-42bd-aa13-3f875ade89ce",
     "type": "lvl2",
     "url": "/utils/is-ssr#return-value",
     "hierarchy": { "lvl1": "isSSR", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "19be904c-61d3-48c6-973f-5238038bccde",
+    "id": "028074a6-dd2e-46ca-bb87-1d6059e03371",
     "type": "lvl2",
     "url": "/utils/is-ssr#usage",
     "hierarchy": { "lvl1": "isSSR", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "noop",
-    "id": "a8fc45d9-0cdc-4581-a5d7-47a952e01e2d",
+    "id": "51989a6b-3e1f-4b6f-8ead-931dec141de9",
     "type": "lvl1",
     "url": "/utils/noop",
     "hierarchy": { "lvl1": "noop" }
   },
   {
     "content": "Import",
-    "id": "787b50aa-df9c-4971-b962-d4d0260b2513",
+    "id": "e0cb66f9-5dd3-4d46-9c01-401ae5f3cae6",
     "type": "lvl2",
     "url": "/utils/noop#import",
     "hierarchy": { "lvl1": "noop", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "d70d5da0-1678-45b1-9e6a-da602af14a3e",
+    "id": "e405e524-0fb3-4b53-83cc-7c62c71bb4b3",
     "type": "lvl2",
     "url": "/utils/noop#return-value",
     "hierarchy": { "lvl1": "noop", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "2ca06e3f-d30a-473e-875e-5f1acc13dbac",
+    "id": "73c1303d-c3fd-4014-91b0-78a17da00dd1",
     "type": "lvl2",
     "url": "/utils/noop#usage",
     "hierarchy": { "lvl1": "noop", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "truncate",
-    "id": "79bf6e52-eff8-444c-b16e-5371d3ae0a2b",
+    "id": "0fa631f6-c01f-45b6-87bf-77b287c80979",
     "type": "lvl1",
     "url": "/utils/truncate",
     "hierarchy": { "lvl1": "truncate" }
   },
   {
     "content": "Import",
-    "id": "73f3e6ec-cc6a-4493-a71b-cbef0158859b",
+    "id": "420539bc-07a5-4ece-a845-00011a7e4d8a",
     "type": "lvl2",
     "url": "/utils/truncate#import",
     "hierarchy": { "lvl1": "truncate", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "8797ffdc-23b3-4e2b-9fad-514b55b3ba86",
+    "id": "8d9c95e5-ae97-4214-a0e0-e6d618aaa14c",
     "type": "lvl2",
     "url": "/utils/truncate#return-value",
     "hierarchy": { "lvl1": "truncate", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "91720298-abd4-43d6-a4e4-fba288f70911",
+    "id": "ddf1da45-2e82-4181-8d36-58f3439d1953",
     "type": "lvl2",
     "url": "/utils/truncate#usage",
     "hierarchy": { "lvl1": "truncate", "lvl2": "Usage", "lvl3": null }
   },
   {
+    "content": "Masking character",
+    "id": "a76b6348-c9e1-4dc0-b509-57556edcc634",
+    "type": "lvl2",
+    "url": "/utils/truncate#masking-character",
+    "hierarchy": {
+      "lvl1": "truncate",
+      "lvl2": "Masking character",
+      "lvl3": null
+    }
+  },
+  {
     "content": "Parameters",
-    "id": "77a25ad4-ee4c-442f-89bb-62a83a668242",
+    "id": "93341e33-0271-4c50-99d6-8818ac30192d",
     "type": "lvl2",
     "url": "/utils/truncate#parameters",
     "hierarchy": { "lvl1": "truncate", "lvl2": "Parameters", "lvl3": null }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lerna": "lerna",
     "dev": "turbo run dev --parallel --no-cache",
-    "test": "turbo run test",
+    "test": "lerna run test --",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
   ],
   "scripts": {
     "lerna": "lerna",
-    "start": "lerna run start --stream --parallel",
-    "test": "lerna run test --",
+    "dev": "turbo run dev --parallel --no-cache",
+    "test": "turbo run test",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "build": "lerna run build",
-    "prepublish": "lerna run prepublish",
+    "build": "turbo run build",
     "start:app": "yarn run build && yarn --cwd example && yarn --cwd example start",
     "changeset": "changeset",
     "release": "changeset publish",
@@ -20,9 +19,8 @@
     "release:canary": "changeset publish --tag canary",
     "format": "prettier -c --write \"*/**\"",
     "postinstall": "husky install",
-    "docs": "yarn workspace @dwarvesf/react-toolkit-docs",
-    "docs:build": "yarn search-meta:gen && yarn docs build",
-    "docs:dev": "yarn docs dev",
+    "docs:build": "yarn search-meta:gen && turbo run build --scope=@dwarvesf/react-toolkit-docs --include-dependencies --parallel",
+    "docs:dev": "turbo run dev --scope=@dwarvesf/react-toolkit-docs --include-dependencies --parallel",
     "search-meta:gen": "ts-node scripts/get-search-meta.ts",
     "pkg": "manypkg run",
     "check:pkgs": "manypkg check",
@@ -84,6 +82,27 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@testing-library/react": "^12.1.0"
+    "@testing-library/react": "^12.1.0",
+    "turbo": "^1.0.24"
+  },
+  "turbo": {
+    "pipeline": {
+      "build": {
+        "dependsOn": [
+          "^build"
+        ],
+        "outputs": [
+          "dist/**",
+          ".next/**",
+          "out/**"
+        ]
+      },
+      "test": {
+        "outputs": []
+      },
+      "dev": {
+        "cache": false
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "lerna": "lerna",
     "dev": "turbo run dev --parallel --no-cache",
-    "test": "lerna run test --",
+    "test": "turbo run test --parallel",
+    "test:ci": "turbo run test:ci --parallel",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "build": "turbo run build",
@@ -98,6 +99,9 @@
         ]
       },
       "test": {
+        "outputs": []
+      },
+      "test:ci": {
         "outputs": []
       },
       "dev": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -9,11 +9,10 @@
     "directory": "packages/hooks"
   },
   "scripts": {
-    "start": "tsdx watch --tsconfig tsconfig.build.json --verbose --noClean",
+    "dev": "tsdx watch --tsconfig tsconfig.build.json --verbose --noClean",
     "build": "tsdx build --tsconfig tsconfig.build.json",
     "test": "tsdx test",
-    "lint": "tsdx lint",
-    "prepublish": "npm run build"
+    "lint": "tsdx lint"
   },
   "main": "dist/index.js",
   "module": "dist/react.esm.js",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -12,6 +12,7 @@
     "dev": "tsdx watch --tsconfig tsconfig.build.json --verbose --noClean",
     "build": "tsdx build --tsconfig tsconfig.build.json",
     "test": "tsdx test",
+    "test:ci": "tsdx test --ci --coverage",
     "lint": "tsdx lint"
   },
   "main": "dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,11 +9,10 @@
     "directory": "packages/utils"
   },
   "scripts": {
-    "start": "tsdx watch --tsconfig tsconfig.build.json --verbose --noClean",
+    "dev": "tsdx watch --tsconfig tsconfig.build.json --verbose --noClean",
     "build": "tsdx build --tsconfig tsconfig.build.json",
     "test": "tsdx test",
-    "lint": "tsdx lint",
-    "prepublish": "npm run build"
+    "lint": "tsdx lint"
   },
   "main": "dist/index.js",
   "module": "dist/utils.esm.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,6 +12,7 @@
     "dev": "tsdx watch --tsconfig tsconfig.build.json --verbose --noClean",
     "build": "tsdx build --tsconfig tsconfig.build.json",
     "test": "tsdx test",
+    "test:ci": "tsdx test --ci --coverage",
     "lint": "tsdx lint"
   },
   "main": "dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14462,6 +14462,84 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbo-darwin-64@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.0.24.tgz#f135baff0e44f9160c9b027e8c4dd2d5c8bb10a7"
+  integrity sha512-A65Wxp+jBMfI3QX2uObX6DKvk+TxNXTf7ufQTHvRSLeAreB8QiVzJdYE0nC6YdrRwfPgFY3L72dhYd2v8ouXDg==
+
+turbo-darwin-arm64@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.0.24.tgz#c360d7cc6a7403855733e3aebb841b1227fbbb2e"
+  integrity sha512-31zfexqUhvk/CIfAUk2mwjlpEjIURXu4QG8hoWlGxpcpAhlnkIX6CXle+LoQSnU3+4EbNe2SE92fYXsT/SnHAg==
+
+turbo-freebsd-64@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.0.24.tgz#9ef8914e7d1aaa995a8001a0ad81f7cc4520d332"
+  integrity sha512-vZYbDkOHH5eeQrxsAYldrh2nDY884irtmgJdGbpjryJgnJx+xzriZfoFalm/d1ZfG3ArENRJqGU+k6BriefZzw==
+
+turbo-freebsd-arm64@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.0.24.tgz#12644e8f1b077f9d7afb367f2b8c2a2e0592ca72"
+  integrity sha512-TDIu1PlyusY8AB69KGM4wGrCjtfbzmVF4Hlgf9mVeSWVKzqkRASorOEq1k8KvfZ+sBTS2GBMpqwpa1KVkYpVhw==
+
+turbo-linux-32@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.0.24.tgz#6129f7560f5c48214c1724ae7e8196dedc56de21"
+  integrity sha512-lhhK7914sUtuWYcDO8LV7NQkvTIwpAZlYH0XEOC/OTiYRQJvtKbEySLvefvtwuGjx7cGNI6OYraUsY3WWoK3FA==
+
+turbo-linux-64@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.0.24.tgz#221e3e14037e8fc3108e12a62de209d8a47f0348"
+  integrity sha512-EbfdrkwVsHDG7AIVQ1enWHoD6riAApx4VRAuFcQHTvJU9e+BuOQBMjb7e9jO4mUrpumtN3n20tP+86odRwsk5g==
+
+turbo-linux-arm64@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.0.24.tgz#95891e7d4375ccbf2478677568557948be33717a"
+  integrity sha512-H4rqlgP2L7G3iAB/un/7DclExzLUkQ1NoZ0p/1Oa7Wb8H1YUlc8GkwUmpIFd5AOFSPL75DjYvlS8T5Tm23i+1A==
+
+turbo-linux-arm@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.0.24.tgz#f5acb74170a8b5a787915e799e7b52840c7c6982"
+  integrity sha512-lCNDVEkwxcn0acyPFVJgV5N5vKAP4LfXb+8uW/JpGHVoPHSONKtzYQG05J1KbHXpIjUT+DNgFtshtsdZYOewZQ==
+
+turbo-linux-mips64le@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.0.24.tgz#f2cc99570222ac42fdcc0d0638f13bc0176859f9"
+  integrity sha512-AmrgQUDIe9AdNyh5YrI6pfMTUHD/gYfbylNmedLuN5Al3xINdZObcISzd/7VWd+V8wNW/1b9lUnt70Rv/KExfA==
+
+turbo-linux-ppc64le@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.0.24.tgz#4d9508290d24cfdbaca24e57d8bcd0127281e2ed"
+  integrity sha512-+6ESjsfrvRUr1AsurNcRTrqYr+XHG8g763+hXLog1MP9mn1cufZqWlAyE4G8/MLXDHsEKgK+tXqPLIyLBRjLEw==
+
+turbo-windows-32@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.0.24.tgz#2bf906c0cc9d675afc4693221fc339ade29e6c13"
+  integrity sha512-pqRys+FfHxuLVmW/AariITL5qpItp4WPAsYnWLx4u7VpCOO/qmTAI/SL7/jnTm4gxjBv3uf//lisu0AvEZd+TA==
+
+turbo-windows-64@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.0.24.tgz#5dd30b10110f2bb69caa479ddd72b4c471fb0dea"
+  integrity sha512-YHAWha5XkW0Ate1HtwhzFD32kZFXtC8KB4ReEvHc9GM2inQob1ZinvktS0xi5MC5Sxl9+bObOWmsxeZPOgNCFA==
+
+turbo@^1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.0.24.tgz#5efdeb44aab2f5e97b24a3e0ed4a159bfcd0a877"
+  integrity sha512-bfOr7iW48+chDl+yKiZ5FIWzXOF6xOIyrAGPaWI+I5CdD27IZCEGvqvTV/weaHvjLbV7otybHQ56XCybBlVjoA==
+  optionalDependencies:
+    turbo-darwin-64 "1.0.24"
+    turbo-darwin-arm64 "1.0.24"
+    turbo-freebsd-64 "1.0.24"
+    turbo-freebsd-arm64 "1.0.24"
+    turbo-linux-32 "1.0.24"
+    turbo-linux-64 "1.0.24"
+    turbo-linux-arm "1.0.24"
+    turbo-linux-arm64 "1.0.24"
+    turbo-linux-mips64le "1.0.24"
+    turbo-linux-ppc64le "1.0.24"
+    turbo-windows-32 "1.0.24"
+    turbo-windows-64 "1.0.24"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
#### What's this PR do?

- [x] Add `turborepo` to handle build caching
  - Running `yarn build` will run `build` command for `docs`, `hooks` and `utils`.
- [x] Remove `prepublish` script because we should use `yarn build` to utilize cache 🤔

#### What are the relevant Git tickets?

https://github.com/dwarvesf/react-toolkit/issues/31

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/11691985/148988760-b6d2a733-fd1c-43b6-86a3-951622316dba.png)

#### Notes

- We still have to run `yarn test` with `lerna` because `turborepo` hasn't supported flags forwarding yet. E.g. `turbo run test --ci --coverage` will throw error because those flags are not supported by `turbo run`
- `yarn docs:build` can only use caches for `hooks` and `utils` because for `docs`, `search-meta` is always newly generated
- `tsdx` is still being used because it's being used heavily & without much config. `tsc` is a viable alternative, but it requires more configs:
  - Specify support for ESM
  - Need to specify `jest` for testing & `eslint` for linting