### PR TITLE
fix: missing prepublish script

### DIFF
--- a/.changeset/small-eggs-poke.md
+++ b/.changeset/small-eggs-poke.md
@@ -1,0 +1,8 @@
+---
+'@dwarvesf/react-toolkit-docs': patch
+'@dwarvesf/react-eslint-config': patch
+'@dwarvesf/react-hooks': patch
+'@dwarvesf/react-utils': patch
+---
+
+Add missing `prepublish` script that causes no build ouput on release

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "build": "turbo run build",
+    "prepublish": "yarn run build",
     "start:app": "yarn run build && yarn --cwd example && yarn --cwd example start",
     "changeset": "changeset",
     "release": "changeset publish",


### PR DESCRIPTION
#### What's this PR do?

- [x] Add missing `prepublish` script

### Screenshot
<img width="254" alt="Screen Shot 2022-02-02 at 22 43 30" src="https://user-images.githubusercontent.com/25856620/152187036-ed048e20-2fd4-4d92-8b04-c6f8ed9f34f1.png">

#### Any background context you want to provide? (if appropriate)

- The recent Turborepo migration accidentally removed the `prepublish` script, which is included in the release pipeline (`yarn` -> triggers `prepublish` -> create build output). As a result, both packages (`@dwarvesf/react-hooks@0.6.1` and `@dwarvesf/react-utils@0.4.0`) has no build artifact when viewed in `node_modules` (check screenshot)